### PR TITLE
Refactoring Fourier metrics

### DIFF
--- a/cloudmetrics/__init__.py
+++ b/cloudmetrics/__init__.py
@@ -1,3 +1,11 @@
 from .metrics.open_sky import open_sky
 from .metrics.iorg import iorg
-from .metrics.fourier import ...
+from .metrics.fourier import (
+    compute_spectra,
+    spectral_anisotropy,
+    spectral_slope,
+    spectral_slope_binned,
+    spectral_length_median,
+    spectral_length_moment,
+    compute_all_spectral,
+)

--- a/cloudmetrics/__init__.py
+++ b/cloudmetrics/__init__.py
@@ -1,2 +1,3 @@
 from .metrics.open_sky import open_sky
 from .metrics.iorg import iorg
+from .metrics.fourier import ...

--- a/cloudmetrics/metrics/fourier.py
+++ b/cloudmetrics/metrics/fourier.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy import fftpack, ndimage, linalg
+from .utils import compute_r_squared
+
+def _get_rad(data):
+    h = data.shape[0]
+    hc = h // 2
+    w = data.shape[1]
+    wc = w // 2
+
+    # create an array of integer radial distances from the center
+    Y, X = np.ogrid[0:h, 0:w]
+    r = np.hypot(X - wc, Y - hc).astype(int)
+
+    return r
+
+
+def _get_psd_1d_radial(psd_2d):
+    r = _get_rad(psd_2d)
+    sh = np.min(psd_2d.shape) // 2
+    N = np.ones(psd_2d.shape)
+
+    # SUM all psd_2d pixels with label 'r' for 0<=r<=wc
+    # Will miss power contributions in 'corners' r>wc
+    r_ran = np.arange(1, sh + 1)
+    rk = np.flip(-(fftpack.fftfreq(int(2 * sh), 1))[sh:])
+    psd_1d = ndimage.sum(psd_2d, r, index=r_ran)
+    Ns = ndimage.sum(N, r, index=r_ran)
+    psd_1d = psd_1d / Ns * rk * 2 * np.pi
+
+    return psd_1d
+
+
+def _get_psd_1d_azimuthal(psd_2d, d_theta=5, r_min=0, r_max=255, return_sectors=False):
+    h = psd_2d.shape[0]
+    w = psd_2d.shape[1]
+    wc = w // 2
+    hc = h // 2
+
+    # note that displaying PSD as image inverts Y axis
+    # create an array of integer angular slices of d_theta
+    Y, X = np.ogrid[0:h, 0:w]
+    theta = np.rad2deg(np.arctan2(-(Y - hc), (X - wc)))
+    theta = np.mod(theta + d_theta / 2 + 360, 360)
+    theta = d_theta * (theta // d_theta)
+    theta = theta.astype(int)
+
+    # mask below r_min and above r_max by setting to -100
+    R = np.hypot(-(Y - hc), (X - wc))
+    mask = np.logical_and(R > r_min, R < r_max)
+    theta = theta + 100
+    theta = np.multiply(mask, theta)
+    theta = theta - 100
+
+    # SUM all psd_2d pixels with label 'theta' for 0<=theta<360 between r_min
+    # and r_max
+    sectors = np.arange(0, 360, int(d_theta))
+    psd_1d = ndimage.sum(psd_2d, theta, index=sectors)
+
+    # normalize each sector to the total sector power
+    pwr_total = np.sum(psd_1d)
+    psd_1d = psd_1d / pwr_total
+
+    if return_sectors:
+        return sectors, psd_1d
+    else:
+        return psd_1d
+
+
+def _detrend(data, regressors):
+    # From https://neurohackweek.github.io/image-processing/02-detrending/
+    regressors = np.vstack([r.ravel() for r in regressors]).T
+    solution = linalg.lstsq(regressors, data.ravel())
+    beta_hat = solution[0]
+    trend = np.dot(regressors, beta_hat)
+    detrended = data - np.reshape(trend, data.shape)
+    return detrended, beta_hat
+
+
+def _hann_rad(data):
+    r = _get_rad(data)
+    sh = np.min(data.shape)
+    shc = sh // 2
+
+    fac = (3.0 * np.pi / 8 - 2 / np.pi) ** (-0.5)
+    # fac  = 1
+    w_han = fac * (1 + np.cos(2 * np.pi * r / sh))
+    w_han[r >= shc] = 0
+
+    return data * w_han
+
+
+def _welch_rad(data):
+    r = _get_rad(data)
+    sh = np.min(data.shape)
+    shc = sh // 2
+
+    w_wel = 1 - (r / shc) ** 2
+    w_wel[r >= shc] = 0
+
+    return data * w_wel
+
+
+def _planck_rad(data, eps=0.1):
+    r = _get_rad(data)
+    N = np.min(data.shape)
+    N2 = N // 2
+    eps_N = int(eps * N)
+    n = N2 - r
+
+    w_planck = np.zeros(data.shape)
+    w_planck[(n < eps_N) & (n >= 1)] = (
+        1
+        + np.exp(
+            eps_N / n[(n < eps_N) & (n >= 1)] - eps_N / (eps_N - n[(n < eps_N) & (n >= 1)])
+        )
+    ) ** (-1)
+    w_planck[eps_N <= n] = 1
+
+    return data * w_planck
+
+def _bin_average(k1d, psd_1d_rad, n_bins):
+    
+    # Average over bins
+    k0 = np.log10(k1d[0])
+    kmax = np.log10(k1d[-1])
+    bins_edges = np.logspace(k0, kmax, n_bins + 1)
+    bins_centres = np.exp((np.log(bins_edges[1:]) + np.log(bins_edges[:-1])) / 2)
+    psd_bin = np.zeros(len(bins_edges) - 1)
+    for i in range(len(bins_edges) - 1):
+        imax = np.where(k1d < bins_edges[i + 1])[0][-1]
+        imin = np.where(k1d >= bins_edges[i])[0]
+        if len(imin) == 0:
+            continue  # You have gone beyond the available wavenumbers
+        else:
+            imin = imin[0]
+        if imin == imax:
+            psdi = psd_1d_rad[imin]
+        else:
+            psdi = psd_1d_rad[imin:imax]
+        psd_bin[i] = np.mean(psdi)
+
+    # Filter empty bins
+    bins_centres = bins_centres[psd_bin != 0]
+    psd_bin = psd_bin[psd_bin != 0]
+    
+    return bins_centres, psd_bin
+
+def _debug_plot(cloud_scalar, k1d, psd_1d, b0, beta, r_squared_beta,
+                bins_centres, psd_bins, beta_binned, b0_binned, r_squared_binned,
+                l_spec_median, l_spec_mom):
+    
+        fig, axs = plt.subplots(ncols=2, figsize=(8, 4))
+        axs[0].imshow(cloud_scalar, "gray")
+        axs[0].axis("off")
+        axs[0].set_title("Clouds")
+        axs[1].scatter(np.log(k1d), np.log(psd_1d), s=2.5, c="k")
+        axs[1].plot(np.log(k1d), b0 + beta * np.log(k1d), c="k")
+        axs[1].scatter(np.log(bins_centres), np.log(psd_bins), s=2.5, c="C1")
+        axs[1].axvline(np.log(1/l_spec_mom), c="grey")
+
+        locs = axs[1].get_xticks().tolist()
+        labs = [x for x in axs[1].get_xticks()]
+        Dticks = dict(zip(locs, labs))
+        Dticks[np.log(1/l_spec_mom)] = r"1/L"
+        locas = list(Dticks.keys())
+        labes = list(Dticks.values())
+        axs[1].set_xticks(locas)
+        axs[1].set_xticklabels(labes)
+
+        axs[1].plot(np.log(bins_centres), b0_binned + beta_binned * np.log(bins_centres), c="C1")
+        axs[1].annotate("Direct", (0.7, 0.9), xycoords="axes fraction", fontsize=10)
+        axs[1].annotate(
+            r"$R^2$=" + str(round(r_squared_beta, 3)),
+            (0.7, 0.8),
+            xycoords="axes fraction",
+            fontsize=10,
+        )
+        axs[1].annotate(
+            r"$\beta=$" + str(round(beta, 3)),
+            (0.7, 0.7),
+            xycoords="axes fraction",
+            fontsize=10,
+        )
+        axs[1].annotate(
+            r"L (median) = " + str(round(l_spec_median, 3)),
+            (0.7, 0.6),
+            xycoords="axes fraction",
+            fontsize=10,
+        )
+        axs[1].annotate(
+            r"L (moment) =" + str(round(l_spec_mom, 3)),
+            (0.7, 0.5),
+            xycoords="axes fraction",
+            fontsize=10,
+        )
+        axs[1].annotate(
+            "Bin-averaged",
+            (0.4, 0.9),
+            xycoords="axes fraction",
+            color="C1",
+            fontsize=10,
+        )
+        axs[1].annotate(
+            r"$R^2$=" + str(round(r_squared_binned, 3)),
+            (0.4, 0.8),
+            xycoords="axes fraction",
+            color="C1",
+            fontsize=10,
+        )
+        axs[1].annotate(
+            r"$\beta_a=$" + str(round(beta_binned, 3)),
+            (0.4, 0.7),
+            xycoords="axes fraction",
+            color="C1",
+            fontsize=10,
+        )
+        axs[1].set_xlabel(r"$\ln k$", fontsize=10)
+        axs[1].set_ylabel(r"$\ln E(k)$", fontsize=10)
+        axs[1].grid()
+        axs[1].set_title("1D Spectrum")
+        plt.tight_layout()
+        plt.show()
+
+def compute_spectra(cloud_scalar,
+                    dx=1,
+                    periodic_domain=False,
+                    apply_detrending=False,
+                    window=None):
+    """
+    Compute energy-preserving 2D FFT of input cloud_scalar field, which is
+    assued to be square, computes the spectral power of this field and 
+    decomposes this into radial and azimuthal power spectral densities.
+
+    Parameters
+    ----------
+    cloud_scalar : numpy array of shape (npx,npx) - npx is number of pixels
+            Cloud mask field.
+    dx : int, optional
+        Horizontal (uniform) grid spacing, for computing wavenumbers. The
+        default is 1.
+    periodic_domain : Bool, optional
+        Whether the domain is periodic. If False, choose an appropriate window
+        to apply before performing the FFT. The default is False.
+    apply_detrending : Bool, optional
+        Whether to remove a blinear fit of the input scalar field. The default 
+        is False.
+    window : String, optional
+        Which windowing function to apply. Set to a value in 
+        ['Hann', 'Welch', 'Planck']. The default is None, corresponding to no
+        applied windowing.
+
+    Returns
+    -------
+    k1d : 1D numpy array
+        Radial 1D wavenumbers of the FFT, whose wavelength is 1/k1d
+    psd_1d_rad: 1D numpy array
+        Radial 1D power spectral density of the cloud_scalar field
+    psd_1d_azi: 1D numpy array
+        Azimuthal 1D power spectral density of the cloud_scalar field
+    """
+     
+    # TODO: This explicitly assumes square domains
+
+    # General observations
+    # Windowing   : Capturing more information is beneficial
+    #               (None>Planck>Welch>Hann window)
+    # Detrending  : Mostly imposes unrealistic gradients
+    # Using image : Less effective at reproducing trends in 2D org plane
+    # Binning     : Emphasises lower k and ignores higher k
+    # Assumptions : 2D Fourier spectrum is isotropic
+    #               Impact of small-scale errors is small
+
+    [X, Y] = np.meshgrid(
+        np.arange(cloud_scalar.shape[0]), np.arange(cloud_scalar.shape[1]), indexing="ij"
+    )
+
+    # Detrending
+    if apply_detrending:
+        cloud_scalar, bDt = _detrend(cloud_scalar, [X, Y])
+
+    # Windowing
+    if periodic_domain:
+        if window == "Planck":
+            cloud_scalar = _planck_rad(cloud_scalar)  # Planck-taper window
+        elif window == "Welch":
+            cloud_scalar = _welch_rad(cloud_scalar)  # Welch window
+        elif window == "Hann":
+            cloud_scalar = _hann_rad(cloud_scalar)  # Hann window
+
+    # FFT
+    F = fftpack.fft2(cloud_scalar)  # 2D FFT (no prefactor)
+    F = fftpack.fftshift(F)  # Shift so k0 is centred
+    psd_2d = np.abs(F) ** 2 / np.prod(cloud_scalar.shape)  # Energy-preserving 2D PSD
+    psd_1d_rad = _get_psd_1d_radial(psd_2d)  # Azimuthal integral-> 1D radial PSD
+    psd_1d_azi = _get_psd_1d_azimuthal(psd_2d)  # Radial integral -> Sector 1D PSD
+
+    # Wavenumbers
+    shp = np.min(cloud_scalar.shape)
+    k1d = -(fftpack.fftfreq(shp, dx))[shp // 2 :]
+    k1d = np.flip(k1d)
+    
+    return k1d, psd_1d_rad, psd_1d_azi
+
+
+def spectral_anisotropy(psd_1d_azi):
+    """
+    Compute a measure of the spectral anisotropy, by computing the ratio
+    between the smallest and largest PSD in an azimuthal sector of the 2D
+    PSD
+
+    Parameters
+    ----------
+    psd_1d_azi : 1D numpy array
+        PSD in sectors of 1 degree of the 2D PSD.
+
+    Returns
+    -------
+    spectral_anisotropy
+        Spectral anisotropy.
+
+    """
+    
+    return 1 - np.min(psd_1d_azi) / np.max(psd_1d_azi)
+
+def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
+    """
+    Compute a least squares fit of the slope of the 1D radial PSD, which turns 
+    out to be a reasonable measure for the dominant length scale of the 
+    cloud_scalar. 
+
+    Parameters
+    ----------
+    k1d : 1D numpy array
+        Radial wavenumbers.
+    psd_1d_rad :  1D numpy array
+        1D radial PSD.
+    return_intercept : Bool, optional
+        Whether to return the y-intercept of the fit (e.g. for plotting). 
+        Default is False.
+
+    Returns
+    -------
+    beta : float
+        Slope of the fitted 1D radial PSD.
+    b0 : float
+        Intercept of the fit. Only returned if return_intercept=True.
+
+    """
+    
+    beta, b0 = np.polyfit(np.log(k1d), np.log(psd_1d_rad), 1)
+    if return_intercept:
+        return beta, b0
+    else:
+        return beta
+
+def spectral_slope_binned(k1d, psd_1d_rad, n_bins=10, return_intercept=False):
+    """
+    Similar to spectral_slope, this computes a least squares fit of the slope of 
+    the 1D radial PSD, but coarsens the PSD into averages over logarithmically
+    spaced bins first, to weight large and small scales more equally.
+
+    Parameters
+    ----------
+    k1d : 1D numpy array
+        Radial wavenumbers.
+    psd_1d_rad :  1D numpy array
+        1D radial PSD.
+    n_bins : int, optional
+        Number of logarithmically spaced bins. The default is 10.
+    return_intercept : Bool, optional
+        Whether to return the y-intercept of the fit (e.g. for plotting). 
+        Default is False.
+
+    Returns
+    -------
+    beta : float
+        Slope of the fitted 1D radial PSD.
+    b0 : float
+        Intercept of the fit. Only returned if return_intercept=True.
+
+    """
+
+    bins_centres, psd_bins = _bin_average(k1d, psd_1d_rad, n_bins)
+
+    # Spectral slope beta
+    if psd_bins.shape[0] != 0:
+        beta, b0 = np.polyfit(np.log(bins_centres[1:-1]), np.log(psd_bins[1:-1]), 1)
+    else:
+        beta, b0 = float("nan"), float("nan")
+    
+    if return_intercept:
+        return beta, b0
+    else:
+        return beta
+
+def spectral_length_median(k1d, psd_1d_rad):
+    """
+    Spectral length scale based on wavenumber with median amount of spectral
+    power. Based on de Roode et al. (2004) https://doi.org/10.1175/1520-0469(2004)061<0403:LSHLIL>2.0.CO;2
+
+    Parameters
+    ----------
+    k1d : 1D numpy array
+        Radial wavenumbers.
+    psd_1d_rad :  1D numpy array
+        1D radial PSD.
+
+    Returns
+    -------
+    l_spec : float
+        Median spectral length scale.
+
+    """
+
+    # Spectral length scale as de Roode et al. (2004), using true median
+    # sumps = np.cumsum(psd1); sumps/=sumps[-1]
+    # kcrit = np.where(sumps>1/2)[0][0]
+    # lSpec = 1./kcrit
+
+    # Spectral length scale as de Roode et al. (2004) using ogive
+    var_tot = np.trapz(psd_1d_rad, k1d)
+    i = 0
+    vari = var_tot + 1
+    while vari > 2.0 / 3 * var_tot:
+        vari = np.trapz(psd_1d_rad[i:], k1d[i:])
+        i += 1
+    kcrit = k1d[i - 1]
+    l_spec = 1.0 / kcrit
+    
+    return l_spec
+
+def spectral_length_moment(k1d, psd_1d_rad, order=1):
+    """
+    Spectral length scale based on wavenumber that corresponds to the order-th
+    moment of the 1D radial PSD. Based on Pino et al. (2006),
+    doi: 10.1007/s10546-006-9080-6
+
+    Parameters
+    ----------
+    k1d : 1D numpy array
+        Radial wavenumbers.
+    psd_1d_rad :  1D numpy array
+        1D radial PSD.
+    order : int, optional
+        Which moment to base the length scale on. The default is 1 and
+        corresponds to the spectral mean.
+
+    Returns
+    -------
+    l_spec : float
+        Spectral length scale.
+
+    """
+
+    var_tot = np.trapz(psd_1d_rad, k1d)
+    kmom = np.trapz(psd_1d_rad * k1d ** order, k1d) / var_tot
+    l_spec = 1.0 / kmom
+
+    return l_spec
+
+def compute_all(cloud_scalar,
+                dx=1,
+                periodic_domain=False,
+                apply_detrending=False,
+                window=None,
+                n_bins=10,
+                order=1,
+                debug=False):
+
+    k1d, psd_1d_rad, psd_1d_azi = compute_spectra(cloud_scalar,
+                                                  dx=dx,
+                                                  periodic_domain=periodic_domain,
+                                                  apply_detrending=apply_detrending,
+                                                  window=window)
+    anisotropy = spectral_anisotropy(psd_1d_azi)
+    beta, b0 = spectral_slope(k1d, psd_1d_rad, return_intercept=True)
+    r_squared = compute_r_squared(np.log(k1d), np.log(psd_1d_rad), [beta, b0])
+    beta_binned, b0_binned = spectral_slope_binned(k1d, psd_1d_rad, n_bins=n_bins,return_intercept=True)
+    bins_centres, psd_bins = _bin_average(k1d, psd_1d_rad, n_bins)
+    r_squared_binned = compute_r_squared(np.log(bins_centres[1:-1]), np.log(psd_bins[1:-1]), [betaa, b0a])
+    l_spec_median = spectral_length_median(k1d, psd_1d_rad)
+    l_spec_moment = spectral_length_moment(k1d, psd_1d_rad, order=order)
+    
+    if debug:
+        _debug_plot(cloud_scalar, k1d, psd_1d_rad, b0, beta, r_squared,
+                bins_centres, psd_bins, beta_binned, b0_binned, r_squared_binned,
+                l_spec_median, l_spec_moment)
+
+    return anisotropy, beta, beta_binned, l_spec_median, l_spec_moment
+

--- a/cloudmetrics/metrics/fourier.py
+++ b/cloudmetrics/metrics/fourier.py
@@ -4,9 +4,12 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import fftpack, ndimage, linalg
-from .utils import compute_r_squared
+from scipy.optimize import curve_fit
+from ..utils import compute_r_squared
+
 
 def _get_rad(data):
+    # From https://medium.com/tangibit-studios/2d-spectrum-characterization-e288f255cc59
     h = data.shape[0]
     hc = h // 2
     w = data.shape[1]
@@ -14,28 +17,42 @@ def _get_rad(data):
 
     # create an array of integer radial distances from the center
     Y, X = np.ogrid[0:h, 0:w]
-    r = np.hypot(X - wc, Y - hc).astype(int)
+    r = np.hypot(X - wc, Y - hc)
 
     return r
 
 
-def _get_psd_1d_radial(psd_2d):
-    r = _get_rad(psd_2d)
-    sh = np.min(psd_2d.shape) // 2
-    N = np.ones(psd_2d.shape)
+def _get_psd_1d_radial(psd_2d, dx):
 
-    # SUM all psd_2d pixels with label 'r' for 0<=r<=wc
-    # Will miss power contributions in 'corners' r>wc
-    r_ran = np.arange(1, sh + 1)
-    rk = np.flip(-(fftpack.fftfreq(int(2 * sh), 1))[sh:])
-    psd_1d = ndimage.sum(psd_2d, r, index=r_ran)
-    Ns = ndimage.sum(N, r, index=r_ran)
-    psd_1d = psd_1d / Ns * rk * 2 * np.pi
+    # TODO: Assumes even number of points in psd_2d and square domain
+
+    N = np.min(psd_2d.shape)
+    L = int(N * dx)
+
+    # Index radii corresponding to horizontal wavenumber 2*pi/L*r
+    r = _get_rad(psd_2d)
+    r_int = np.round(r).astype(int)
+    rp = np.arange(1, N // 2 + 1)
+
+    # SUM all psd_2d pixels with label 'kh' for 0<=kh<=N/2 * 2*pi*L
+    # Will miss power contributions in 'corners' kh>N/2 * 2*pi*L
+    # This is still a variance quantity.
+    psd_1d = ndimage.sum(psd_2d, r_int, index=rp)
+
+    # Compute prefactor that converts to spectral density and corrects for
+    # annulus discreteness
+    Ns = ndimage.sum(np.ones(psd_2d.shape), r_int, index=rp)
+
+    kp = 2 * np.pi / L * ndimage.sum(r, r_int, index=rp) / Ns
+
+    psd_1d *= L ** 2 * kp / (2 * np.pi * N ** 2 * Ns)
 
     return psd_1d
 
 
-def _get_psd_1d_azimuthal(psd_2d, d_theta=5, r_min=0, r_max=255, return_sectors=False):
+def _get_psd_1d_azimuthal(psd_2d, d_theta=5, return_sectors=False):
+
+    # From https://medium.com/tangibit-studios/2d-spectrum-characterization-e288f255cc59
     h = psd_2d.shape[0]
     w = psd_2d.shape[1]
     wc = w // 2
@@ -51,7 +68,7 @@ def _get_psd_1d_azimuthal(psd_2d, d_theta=5, r_min=0, r_max=255, return_sectors=
 
     # mask below r_min and above r_max by setting to -100
     R = np.hypot(-(Y - hc), (X - wc))
-    mask = np.logical_and(R > r_min, R < r_max)
+    mask = np.logical_and(R > 0, R < np.min([wc, hc]) - 1)
     theta = theta + 100
     theta = np.multiply(mask, theta)
     theta = theta - 100
@@ -82,7 +99,7 @@ def _detrend(data, regressors):
 
 
 def _hann_rad(data):
-    r = _get_rad(data)
+    r = _get_rad(data).astype(int)
     sh = np.min(data.shape)
     shc = sh // 2
 
@@ -95,7 +112,7 @@ def _hann_rad(data):
 
 
 def _welch_rad(data):
-    r = _get_rad(data)
+    r = _get_rad(data).astype(int)
     sh = np.min(data.shape)
     shc = sh // 2
 
@@ -106,7 +123,7 @@ def _welch_rad(data):
 
 
 def _planck_rad(data, eps=0.1):
-    r = _get_rad(data)
+    r = _get_rad(data).astype(int)
     N = np.min(data.shape)
     N2 = N // 2
     eps_N = int(eps * N)
@@ -116,15 +133,17 @@ def _planck_rad(data, eps=0.1):
     w_planck[(n < eps_N) & (n >= 1)] = (
         1
         + np.exp(
-            eps_N / n[(n < eps_N) & (n >= 1)] - eps_N / (eps_N - n[(n < eps_N) & (n >= 1)])
+            eps_N / n[(n < eps_N) & (n >= 1)]
+            - eps_N / (eps_N - n[(n < eps_N) & (n >= 1)])
         )
     ) ** (-1)
     w_planck[eps_N <= n] = 1
 
     return data * w_planck
 
+
 def _bin_average(k1d, psd_1d_rad, n_bins):
-    
+
     # Average over bins
     k0 = np.log10(k1d[0])
     kmax = np.log10(k1d[-1])
@@ -147,90 +166,100 @@ def _bin_average(k1d, psd_1d_rad, n_bins):
     # Filter empty bins
     bins_centres = bins_centres[psd_bin != 0]
     psd_bin = psd_bin[psd_bin != 0]
-    
+
     return bins_centres, psd_bin
 
-def _debug_plot(cloud_scalar, k1d, psd_1d, b0, beta, r_squared_beta,
-                bins_centres, psd_bins, beta_binned, b0_binned, r_squared_binned,
-                l_spec_median, l_spec_mom):
-    
-        fig, axs = plt.subplots(ncols=2, figsize=(8, 4))
-        axs[0].imshow(cloud_scalar, "gray")
-        axs[0].axis("off")
-        axs[0].set_title("Clouds")
-        axs[1].scatter(np.log(k1d), np.log(psd_1d), s=2.5, c="k")
-        axs[1].plot(np.log(k1d), b0 + beta * np.log(k1d), c="k")
-        axs[1].scatter(np.log(bins_centres), np.log(psd_bins), s=2.5, c="C1")
-        axs[1].axvline(np.log(1/l_spec_mom), c="grey")
 
-        locs = axs[1].get_xticks().tolist()
-        labs = [x for x in axs[1].get_xticks()]
-        Dticks = dict(zip(locs, labs))
-        Dticks[np.log(1/l_spec_mom)] = r"1/L"
-        locas = list(Dticks.keys())
-        labes = list(Dticks.values())
-        axs[1].set_xticks(locas)
-        axs[1].set_xticklabels(labes)
+def _debug_plot(
+    cloud_scalar,
+    k1d,
+    psd_1d,
+    b0,
+    beta,
+    r_squared_beta,
+    bins_centres,
+    psd_bins,
+    beta_binned,
+    b0_binned,
+    r_squared_binned,
+    l_spec_median,
+    l_spec_mom,
+):
 
-        axs[1].plot(np.log(bins_centres), b0_binned + beta_binned * np.log(bins_centres), c="C1")
-        axs[1].annotate("Direct", (0.7, 0.9), xycoords="axes fraction", fontsize=10)
-        axs[1].annotate(
-            r"$R^2$=" + str(round(r_squared_beta, 3)),
-            (0.7, 0.8),
-            xycoords="axes fraction",
-            fontsize=10,
-        )
-        axs[1].annotate(
-            r"$\beta=$" + str(round(beta, 3)),
-            (0.7, 0.7),
-            xycoords="axes fraction",
-            fontsize=10,
-        )
-        axs[1].annotate(
-            r"L (median) = " + str(round(l_spec_median, 3)),
-            (0.7, 0.6),
-            xycoords="axes fraction",
-            fontsize=10,
-        )
-        axs[1].annotate(
-            r"L (moment) =" + str(round(l_spec_mom, 3)),
-            (0.7, 0.5),
-            xycoords="axes fraction",
-            fontsize=10,
-        )
-        axs[1].annotate(
-            "Bin-averaged",
-            (0.4, 0.9),
-            xycoords="axes fraction",
-            color="C1",
-            fontsize=10,
-        )
-        axs[1].annotate(
-            r"$R^2$=" + str(round(r_squared_binned, 3)),
-            (0.4, 0.8),
-            xycoords="axes fraction",
-            color="C1",
-            fontsize=10,
-        )
-        axs[1].annotate(
-            r"$\beta_a=$" + str(round(beta_binned, 3)),
-            (0.4, 0.7),
-            xycoords="axes fraction",
-            color="C1",
-            fontsize=10,
-        )
-        axs[1].set_xlabel(r"$\ln k$", fontsize=10)
-        axs[1].set_ylabel(r"$\ln E(k)$", fontsize=10)
-        axs[1].grid()
-        axs[1].set_title("1D Spectrum")
-        plt.tight_layout()
-        plt.show()
+    fig, axs = plt.subplots(ncols=2, figsize=(8, 4))
+    axs[0].imshow(cloud_scalar, "gray")
+    axs[0].axis("off")
+    axs[0].set_title("Clouds")
+    axs[1].scatter(k1d, psd_1d, s=2.5, c="k")
+    axs[1].plot(k1d, b0 * k1d ** beta, c="k")
+    axs[1].scatter(bins_centres, psd_bins, s=2.5, c="C1")
+    axs[1].axvline(2 * np.pi / l_spec_mom, c="grey")
 
-def compute_spectra(cloud_scalar,
-                    dx=1,
-                    periodic_domain=False,
-                    apply_detrending=False,
-                    window=None):
+    locs = axs[1].get_xticks().tolist()
+    labs = [x for x in axs[1].get_xticks()]
+    Dticks = dict(zip(locs, labs))
+    Dticks[2 * np.pi / l_spec_mom] = r"2pi/lspec"
+    locas = list(Dticks.keys())
+    labes = list(Dticks.values())
+    axs[1].set_xticks(locas)
+    axs[1].set_xticklabels(labes)
+
+    axs[1].plot(bins_centres, b0_binned * bins_centres ** beta_binned, c="C1")
+    axs[1].annotate("Direct", (0.8, 0.9), xycoords="axes fraction", fontsize=10)
+    axs[1].annotate(
+        r"$R^2$=" + str(round(r_squared_beta, 3)),
+        (0.8, 0.8),
+        xycoords="axes fraction",
+        fontsize=10,
+    )
+    axs[1].annotate(
+        r"$\beta=$" + str(round(beta, 3)),
+        (0.8, 0.7),
+        xycoords="axes fraction",
+        fontsize=10,
+    )
+    axs[1].annotate(
+        r"L (median) = " + str(round(l_spec_median, 3)),
+        (0.8, 0.6),
+        xycoords="axes fraction",
+        fontsize=10,
+    )
+    axs[1].annotate(
+        r"L (moment) =" + str(round(l_spec_mom, 3)),
+        (0.8, 0.5),
+        xycoords="axes fraction",
+        fontsize=10,
+    )
+    axs[1].annotate(
+        "Bin-averaged", (0.4, 0.9), xycoords="axes fraction", color="C1", fontsize=10,
+    )
+    axs[1].annotate(
+        r"$R^2$=" + str(round(r_squared_binned, 3)),
+        (0.4, 0.8),
+        xycoords="axes fraction",
+        color="C1",
+        fontsize=10,
+    )
+    axs[1].annotate(
+        r"$\beta_a=$" + str(round(beta_binned, 3)),
+        (0.4, 0.7),
+        xycoords="axes fraction",
+        color="C1",
+        fontsize=10,
+    )
+    axs[1].set_xscale("log")
+    axs[1].set_yscale("log")
+    axs[1].set_xlabel(r"$k$", fontsize=10)
+    axs[1].set_ylabel(r"$kF(C)^2$", fontsize=10)
+    axs[1].grid()
+    axs[1].set_title("1D radial pectrum")
+    plt.tight_layout()
+    plt.show()
+
+
+def compute_spectra(
+    cloud_scalar, dx=1, periodic_domain=False, apply_detrending=False, window=None
+):
     """
     Compute energy-preserving 2D FFT of input cloud_scalar field, which is
     assued to be square, computes the spectral power of this field and 
@@ -257,13 +286,13 @@ def compute_spectra(cloud_scalar,
     Returns
     -------
     k1d : 1D numpy array
-        Radial 1D wavenumbers of the FFT, whose wavelength is 1/k1d
+        Radial 1D wavenumbers of the FFT, whose wavelength is 2*pi/k1d
     psd_1d_rad: 1D numpy array
         Radial 1D power spectral density of the cloud_scalar field
     psd_1d_azi: 1D numpy array
         Azimuthal 1D power spectral density of the cloud_scalar field
     """
-     
+
     # TODO: This explicitly assumes square domains
 
     # General observations
@@ -275,12 +304,13 @@ def compute_spectra(cloud_scalar,
     # Assumptions : 2D Fourier spectrum is isotropic
     #               Impact of small-scale errors is small
 
-    [X, Y] = np.meshgrid(
-        np.arange(cloud_scalar.shape[0]), np.arange(cloud_scalar.shape[1]), indexing="ij"
-    )
-
     # Detrending
     if apply_detrending:
+        [X, Y] = np.meshgrid(
+            np.arange(cloud_scalar.shape[0]),
+            np.arange(cloud_scalar.shape[1]),
+            indexing="ij",
+        )
         cloud_scalar, bDt = _detrend(cloud_scalar, [X, Y])
 
     # Windowing
@@ -296,14 +326,14 @@ def compute_spectra(cloud_scalar,
     F = fftpack.fft2(cloud_scalar)  # 2D FFT (no prefactor)
     F = fftpack.fftshift(F)  # Shift so k0 is centred
     psd_2d = np.abs(F) ** 2 / np.prod(cloud_scalar.shape)  # Energy-preserving 2D PSD
-    psd_1d_rad = _get_psd_1d_radial(psd_2d)  # Azimuthal integral-> 1D radial PSD
+    psd_1d_rad = _get_psd_1d_radial(psd_2d, dx)  # Azimuthal integral-> 1D radial PSD
     psd_1d_azi = _get_psd_1d_azimuthal(psd_2d)  # Radial integral -> Sector 1D PSD
 
     # Wavenumbers
-    shp = np.min(cloud_scalar.shape)
-    k1d = -(fftpack.fftfreq(shp, dx))[shp // 2 :]
-    k1d = np.flip(k1d)
-    
+    N = np.min(cloud_scalar.shape)
+    L = dx * N
+    k1d = 2 * np.pi / L * np.arange(1, N // 2 + 1)
+
     return k1d, psd_1d_rad, psd_1d_azi
 
 
@@ -324,8 +354,9 @@ def spectral_anisotropy(psd_1d_azi):
         Spectral anisotropy.
 
     """
-    
+
     return 1 - np.min(psd_1d_azi) / np.max(psd_1d_azi)
+
 
 def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
     """
@@ -351,12 +382,19 @@ def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
         Intercept of the fit. Only returned if return_intercept=True.
 
     """
-    
-    beta, b0 = np.polyfit(np.log(k1d), np.log(psd_1d_rad), 1)
+
+    # Biased estimator (old version)
+    # beta, b0 = np.polyfit(np.log(k1d), np.log(psd_1d_rad), 1)
+
+    # Unbiased fit of the power law
+    _ = np.seterr(over="ignore")
+    [beta, b0], cov = curve_fit(lambda x, a, b: b * x ** a, k1d, psd_1d_rad)
+
     if return_intercept:
         return beta, b0
     else:
         return beta
+
 
 def spectral_slope_binned(k1d, psd_1d_rad, n_bins=10, return_intercept=False):
     """
@@ -389,19 +427,30 @@ def spectral_slope_binned(k1d, psd_1d_rad, n_bins=10, return_intercept=False):
 
     # Spectral slope beta
     if psd_bins.shape[0] != 0:
-        beta, b0 = np.polyfit(np.log(bins_centres[1:-1]), np.log(psd_bins[1:-1]), 1)
+
+        # Biased estimated (old version)
+        # beta, b0 = np.polyfit(np.log(bins_centres[1:-1]), np.log(psd_bins[1:-1]), 1)
+
+        # Unbiased fit of the power law
+        _ = np.seterr(over="ignore")
+        [beta, b0], cov = curve_fit(
+            lambda x, a, b: b * x ** a, bins_centres[1:-1], psd_bins[1:-1]
+        )
+
     else:
         beta, b0 = float("nan"), float("nan")
-    
+
     if return_intercept:
         return beta, b0
     else:
         return beta
 
+
 def spectral_length_median(k1d, psd_1d_rad):
     """
-    Spectral length scale based on wavenumber with median amount of spectral
-    power. Based on de Roode et al. (2004) https://doi.org/10.1175/1520-0469(2004)061<0403:LSHLIL>2.0.CO;2
+    Spectral length scale based on wavenumber where 2/3 of the spectral power
+    resides in smaller scales than that defined by l_spec. Based on de Roode et al. (2004):
+    https://doi.org/10.1175/1520-0469(2004)061<0403:LSHLIL>2.0.CO;2
 
     Parameters
     ----------
@@ -423,16 +472,18 @@ def spectral_length_median(k1d, psd_1d_rad):
     # lSpec = 1./kcrit
 
     # Spectral length scale as de Roode et al. (2004) using ogive
-    var_tot = np.trapz(psd_1d_rad, k1d)
+    dk1d = k1d[1] - k1d[0]
+    var_tot = np.sum(psd_1d_rad) * dk1d
     i = 0
     vari = var_tot + 1
     while vari > 2.0 / 3 * var_tot:
-        vari = np.trapz(psd_1d_rad[i:], k1d[i:])
+        vari = np.sum(psd_1d_rad[i:]) * dk1d
         i += 1
     kcrit = k1d[i - 1]
-    l_spec = 1.0 / kcrit
-    
+    l_spec = 2 * np.pi / kcrit
+
     return l_spec
+
 
 def spectral_length_moment(k1d, psd_1d_rad, order=1):
     """
@@ -457,39 +508,62 @@ def spectral_length_moment(k1d, psd_1d_rad, order=1):
 
     """
 
-    var_tot = np.trapz(psd_1d_rad, k1d)
-    kmom = np.trapz(psd_1d_rad * k1d ** order, k1d) / var_tot
-    l_spec = 1.0 / kmom
+    kmom = (
+        np.trapz(psd_1d_rad * k1d ** order, k1d) / np.trapz(psd_1d_rad, k1d)
+    ) ** 1 / order
+    l_spec = 2 * np.pi / kmom
 
     return l_spec
 
-def compute_all(cloud_scalar,
-                dx=1,
-                periodic_domain=False,
-                apply_detrending=False,
-                window=None,
-                n_bins=10,
-                order=1,
-                debug=False):
 
-    k1d, psd_1d_rad, psd_1d_azi = compute_spectra(cloud_scalar,
-                                                  dx=dx,
-                                                  periodic_domain=periodic_domain,
-                                                  apply_detrending=apply_detrending,
-                                                  window=window)
+def compute_all_spectral(
+    cloud_scalar,
+    dx=1,
+    periodic_domain=False,
+    apply_detrending=False,
+    window=None,
+    n_bins=10,
+    order=1,
+    debug=False,
+):
+
+    k1d, psd_1d_rad, psd_1d_azi = compute_spectra(
+        cloud_scalar,
+        dx=dx,
+        periodic_domain=periodic_domain,
+        apply_detrending=apply_detrending,
+        window=window,
+    )
     anisotropy = spectral_anisotropy(psd_1d_azi)
     beta, b0 = spectral_slope(k1d, psd_1d_rad, return_intercept=True)
-    r_squared = compute_r_squared(np.log(k1d), np.log(psd_1d_rad), [beta, b0])
-    beta_binned, b0_binned = spectral_slope_binned(k1d, psd_1d_rad, n_bins=n_bins,return_intercept=True)
+    r_squared = compute_r_squared(
+        lambda x, c: c[1] * x ** c[0], [beta, b0], k1d, psd_1d_rad
+    )
+    beta_binned, b0_binned = spectral_slope_binned(
+        k1d, psd_1d_rad, n_bins=n_bins, return_intercept=True
+    )
     bins_centres, psd_bins = _bin_average(k1d, psd_1d_rad, n_bins)
-    r_squared_binned = compute_r_squared(np.log(bins_centres[1:-1]), np.log(psd_bins[1:-1]), [betaa, b0a])
+    r_squared_binned = compute_r_squared(
+        lambda x, c: c[1] * x ** c[0], [beta_binned, b0_binned], bins_centres, psd_bins
+    )
     l_spec_median = spectral_length_median(k1d, psd_1d_rad)
     l_spec_moment = spectral_length_moment(k1d, psd_1d_rad, order=order)
-    
+
     if debug:
-        _debug_plot(cloud_scalar, k1d, psd_1d_rad, b0, beta, r_squared,
-                bins_centres, psd_bins, beta_binned, b0_binned, r_squared_binned,
-                l_spec_median, l_spec_moment)
+        _debug_plot(
+            cloud_scalar,
+            k1d,
+            psd_1d_rad,
+            b0,
+            beta,
+            r_squared,
+            bins_centres,
+            psd_bins,
+            beta_binned,
+            b0_binned,
+            r_squared_binned,
+            l_spec_median,
+            l_spec_moment,
+        )
 
     return anisotropy, beta, beta_binned, l_spec_median, l_spec_moment
-

--- a/cloudmetrics/metrics/fourier.py
+++ b/cloudmetrics/metrics/fourier.py
@@ -231,7 +231,11 @@ def _debug_plot(
         fontsize=10,
     )
     axs[1].annotate(
-        "Bin-averaged", (0.4, 0.9), xycoords="axes fraction", color="C1", fontsize=10,
+        "Bin-averaged",
+        (0.4, 0.9),
+        xycoords="axes fraction",
+        color="C1",
+        fontsize=10,
     )
     axs[1].annotate(
         r"$R^2$=" + str(round(r_squared_binned, 3)),

--- a/cloudmetrics/metrics/fourier.py
+++ b/cloudmetrics/metrics/fourier.py
@@ -272,7 +272,7 @@ def compute_spectra(
     Parameters
     ----------
     cloud_scalar : numpy array of shape (npx,npx) - npx is number of pixels
-            Cloud mask field.
+            Cloud scalar field.
     dx : int, optional
         Horizontal (uniform) grid spacing, for computing wavenumbers. The
         default is 1.
@@ -290,14 +290,17 @@ def compute_spectra(
     Returns
     -------
     k1d : 1D numpy array
-        Radial 1D wavenumbers of the FFT, whose wavelength is 2*pi/k1d
+        Radial 1D wavenumbers of the FFT, whose wavelength is 2*pi/k1d. These are
+        the coordinates at which psd_1d_rad is defined.
     psd_1d_rad: 1D numpy array
-        Radial 1D power spectral density of the cloud_scalar field
+        Radial 1D power spectral density of the cloud_scalar field.
     psd_1d_azi: 1D numpy array
-        Azimuthal 1D power spectral density of the cloud_scalar field
+        Azimuthal 1D power spectral density of the cloud_scalar field.
     """
 
     # TODO: This explicitly assumes square domains
+    if cloud_scalar.shape[0] != cloud_scalar.shape[1]:
+        raise NotImplementedError(f"nx != ny ({cloud_scalar.shape[1]} != {cloud_scalar.shape[0]})")
 
     # General observations
     # Windowing   : Capturing more information is beneficial

--- a/cloudmetrics/metrics/fourier.py
+++ b/cloudmetrics/metrics/fourier.py
@@ -231,7 +231,11 @@ def _debug_plot(
         fontsize=10,
     )
     axs[1].annotate(
-        "Bin-averaged", (0.4, 0.9), xycoords="axes fraction", color="C1", fontsize=10,
+        "Bin-averaged",
+        (0.4, 0.9),
+        xycoords="axes fraction",
+        color="C1",
+        fontsize=10,
     )
     axs[1].annotate(
         r"$R^2$=" + str(round(r_squared_binned, 3)),
@@ -262,7 +266,7 @@ def compute_spectra(
 ):
     """
     Compute energy-preserving 2D FFT of input cloud_scalar field, which is
-    assued to be square, computes the spectral power of this field and 
+    assued to be square, computes the spectral power of this field and
     decomposes this into radial and azimuthal power spectral densities.
 
     Parameters
@@ -276,10 +280,10 @@ def compute_spectra(
         Whether the domain is periodic. If False, choose an appropriate window
         to apply before performing the FFT. The default is False.
     apply_detrending : Bool, optional
-        Whether to remove a blinear fit of the input scalar field. The default 
+        Whether to remove a blinear fit of the input scalar field. The default
         is False.
     window : String, optional
-        Which windowing function to apply. Set to a value in 
+        Which windowing function to apply. Set to a value in
         ['Hann', 'Welch', 'Planck']. The default is None, corresponding to no
         applied windowing.
 
@@ -360,9 +364,9 @@ def spectral_anisotropy(psd_1d_azi):
 
 def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
     """
-    Compute a least squares fit of the slope of the 1D radial PSD, which turns 
-    out to be a reasonable measure for the dominant length scale of the 
-    cloud_scalar. 
+    Compute a least squares fit of the slope of the 1D radial PSD, which turns
+    out to be a reasonable measure for the dominant length scale of the
+    cloud_scalar.
 
     Parameters
     ----------
@@ -371,7 +375,7 @@ def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
     psd_1d_rad :  1D numpy array
         1D radial PSD.
     return_intercept : Bool, optional
-        Whether to return the y-intercept of the fit (e.g. for plotting). 
+        Whether to return the y-intercept of the fit (e.g. for plotting).
         Default is False.
 
     Returns
@@ -398,7 +402,7 @@ def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
 
 def spectral_slope_binned(k1d, psd_1d_rad, n_bins=10, return_intercept=False):
     """
-    Similar to spectral_slope, this computes a least squares fit of the slope of 
+    Similar to spectral_slope, this computes a least squares fit of the slope of
     the 1D radial PSD, but coarsens the PSD into averages over logarithmically
     spaced bins first, to weight large and small scales more equally.
 
@@ -411,7 +415,7 @@ def spectral_slope_binned(k1d, psd_1d_rad, n_bins=10, return_intercept=False):
     n_bins : int, optional
         Number of logarithmically spaced bins. The default is 10.
     return_intercept : Bool, optional
-        Whether to return the y-intercept of the fit (e.g. for plotting). 
+        Whether to return the y-intercept of the fit (e.g. for plotting).
         Default is False.
 
     Returns

--- a/cloudmetrics/metrics/fourier.py
+++ b/cloudmetrics/metrics/fourier.py
@@ -231,11 +231,7 @@ def _debug_plot(
         fontsize=10,
     )
     axs[1].annotate(
-        "Bin-averaged",
-        (0.4, 0.9),
-        xycoords="axes fraction",
-        color="C1",
-        fontsize=10,
+        "Bin-averaged", (0.4, 0.9), xycoords="axes fraction", color="C1", fontsize=10,
     )
     axs[1].annotate(
         r"$R^2$=" + str(round(r_squared_binned, 3)),
@@ -300,7 +296,9 @@ def compute_spectra(
 
     # TODO: This explicitly assumes square domains
     if cloud_scalar.shape[0] != cloud_scalar.shape[1]:
-        raise NotImplementedError(f"nx != ny ({cloud_scalar.shape[1]} != {cloud_scalar.shape[0]})")
+        raise NotImplementedError(
+            f"nx != ny ({cloud_scalar.shape[1]} != {cloud_scalar.shape[0]})"
+        )
 
     # General observations
     # Windowing   : Capturing more information is beneficial

--- a/cloudmetrics/metrics/fractal_dimension.py
+++ b/cloudmetrics/metrics/fractal_dimension.py
@@ -56,7 +56,9 @@ def fractal_dimension(cloud_mask, debug=False):
 
     # Fit the relation: counts = coeffs[1]*sizes**coeffs[0]; coeffs[0]=-Nd
     coeffs = np.polyfit(np.log(sizes), np.log(counts), 1)
-    r_squared = compute_r_squared(lambda x, c: c[1] + c[0] * x, coeffs, np.log(sizes), np.log(counts))
+    r_squared = compute_r_squared(
+        lambda x, c: c[1] + c[0] * x, coeffs, np.log(sizes), np.log(counts)
+    )
     fractal_dim = -coeffs[0]
 
     if debug:

--- a/cloudmetrics/metrics/fractal_dimension.py
+++ b/cloudmetrics/metrics/fractal_dimension.py
@@ -56,7 +56,7 @@ def fractal_dimension(cloud_mask, debug=False):
 
     # Fit the relation: counts = coeffs[1]*sizes**coeffs[0]; coeffs[0]=-Nd
     coeffs = np.polyfit(np.log(sizes), np.log(counts), 1)
-    r_squared = compute_r_squared(np.log(sizes), np.log(counts), coeffs)
+    r_squared = compute_r_squared(lambda x, c: c[1] + c[0] * x, coeffs, np.log(sizes), np.log(counts))
     fractal_dim = -coeffs[0]
 
     if debug:

--- a/cloudmetrics/metrics/iorg.py
+++ b/cloudmetrics/metrics/iorg.py
@@ -20,45 +20,37 @@ def _debug_plot_1(field, placedCircles):
     ax.set_ylim((0, field.shape[0]))
     for i in range(len(placedCircles)):
         circ = plt.Circle(
-            (placedCircles[i].xm, placedCircles[i].yp),
-            placedCircles[i].r,
+            (placedCircles[i].xm, placedCircles[i].yp), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].x, placedCircles[i].yp),
-            placedCircles[i].r,
+            (placedCircles[i].x, placedCircles[i].yp), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xp, placedCircles[i].yp),
-            placedCircles[i].r,
+            (placedCircles[i].xp, placedCircles[i].yp), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xm, placedCircles[i].y),
-            placedCircles[i].r,
+            (placedCircles[i].xm, placedCircles[i].y), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle((placedCircles[i].x, placedCircles[i].y), placedCircles[i].r)
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xp, placedCircles[i].y),
-            placedCircles[i].r,
+            (placedCircles[i].xp, placedCircles[i].y), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xm, placedCircles[i].ym),
-            placedCircles[i].r,
+            (placedCircles[i].xm, placedCircles[i].ym), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].x, placedCircles[i].ym),
-            placedCircles[i].r,
+            (placedCircles[i].x, placedCircles[i].ym), placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xp, placedCircles[i].ym),
-            placedCircles[i].r,
+            (placedCircles[i].xp, placedCircles[i].ym), placedCircles[i].r,
         )
         ax.add_artist(circ)
     ax.grid(which="both")
@@ -89,9 +81,7 @@ def _debug_plot_2(field, posScene, posRand, nndcdfRan, nndcdfSce, iOrg):
     axs[3].set_xlabel("Random field nearest neighbour CDF")
     axs[3].set_ylabel("Scene nearest neighbour CDF")
     axs[3].annotate(
-        r"$I_{org} = $" + str(round(iOrg, 3)),
-        (0.7, 0.1),
-        xycoords="axes fraction",
+        r"$I_{org} = $" + str(round(iOrg, 3)), (0.7, 0.1), xycoords="axes fraction",
     )
     asp = np.diff(axs[3].get_xlim())[0] / np.diff(axs[3].get_ylim())[0]
     axs[3].set_aspect(asp)

--- a/cloudmetrics/metrics/iorg.py
+++ b/cloudmetrics/metrics/iorg.py
@@ -20,37 +20,45 @@ def _debug_plot_1(field, placedCircles):
     ax.set_ylim((0, field.shape[0]))
     for i in range(len(placedCircles)):
         circ = plt.Circle(
-            (placedCircles[i].xm, placedCircles[i].yp), placedCircles[i].r,
+            (placedCircles[i].xm, placedCircles[i].yp),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].x, placedCircles[i].yp), placedCircles[i].r,
+            (placedCircles[i].x, placedCircles[i].yp),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xp, placedCircles[i].yp), placedCircles[i].r,
+            (placedCircles[i].xp, placedCircles[i].yp),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xm, placedCircles[i].y), placedCircles[i].r,
+            (placedCircles[i].xm, placedCircles[i].y),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle((placedCircles[i].x, placedCircles[i].y), placedCircles[i].r)
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xp, placedCircles[i].y), placedCircles[i].r,
+            (placedCircles[i].xp, placedCircles[i].y),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xm, placedCircles[i].ym), placedCircles[i].r,
+            (placedCircles[i].xm, placedCircles[i].ym),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].x, placedCircles[i].ym), placedCircles[i].r,
+            (placedCircles[i].x, placedCircles[i].ym),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
         circ = plt.Circle(
-            (placedCircles[i].xp, placedCircles[i].ym), placedCircles[i].r,
+            (placedCircles[i].xp, placedCircles[i].ym),
+            placedCircles[i].r,
         )
         ax.add_artist(circ)
     ax.grid(which="both")
@@ -81,7 +89,9 @@ def _debug_plot_2(field, posScene, posRand, nndcdfRan, nndcdfSce, iOrg):
     axs[3].set_xlabel("Random field nearest neighbour CDF")
     axs[3].set_ylabel("Scene nearest neighbour CDF")
     axs[3].annotate(
-        r"$I_{org} = $" + str(round(iOrg, 3)), (0.7, 0.1), xycoords="axes fraction",
+        r"$I_{org} = $" + str(round(iOrg, 3)),
+        (0.7, 0.1),
+        xycoords="axes fraction",
     )
     asp = np.diff(axs[3].get_xlim())[0] / np.diff(axs[3].get_ylim())[0]
     axs[3].set_aspect(asp)

--- a/cloudmetrics/utils.py
+++ b/cloudmetrics/utils.py
@@ -139,3 +139,15 @@ def find_nearest_neighbors(data, size=None):
     dists = tree.query(data, 2)
     nn_dist = np.sort(dists[0][:, 1])
     return nn_dist
+
+
+def compute_r_squared(x, y, coeffs):
+
+    p = np.poly1d(coeffs)
+
+    # fit values, and mean
+    yhat = p(x)  # or [p(z) for z in x]
+    ybar = np.sum(y) / len(y)  # or sum(y)/len(y)
+    ssreg = np.sum((yhat - ybar) ** 2)  # or sum([ (yihat - ybar)**2 for yihat in yhat])
+    sstot = np.sum((y - ybar) ** 2)  # or sum([ (yi - ybar)**2 for yi in y])
+    return ssreg / sstot

--- a/cloudmetrics/utils.py
+++ b/cloudmetrics/utils.py
@@ -141,13 +141,15 @@ def find_nearest_neighbors(data, size=None):
     return nn_dist
 
 
-def compute_r_squared(x, y, coeffs):
+def compute_r_squared(func, coeffs, x, y):
 
-    p = np.poly1d(coeffs)
+    # Pseudo-R^2 (equal to R^2 for linear regressions, not interpretable as
+    # variance fraction explained by model for non-linear regression, where
+    # it can be less than zero).
 
     # fit values, and mean
-    yhat = p(x)  # or [p(z) for z in x]
+    yhat = func(x, coeffs)  # or [p(z) for z in x]
     ybar = np.sum(y) / len(y)  # or sum(y)/len(y)
-    ssreg = np.sum((yhat - ybar) ** 2)  # or sum([ (yihat - ybar)**2 for yihat in yhat])
+    ssres = np.sum((y - yhat) ** 2)  # or sum([ (yihat - ybar)**2 for yihat in yhat])
     sstot = np.sum((y - ybar) ** 2)  # or sum([ (yi - ybar)**2 for yi in y])
-    return ssreg / sstot
+    return 1 - ssres / sstot

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -1,0 +1,50 @@
+import pytest
+import numpy as np
+
+import cloudmetrics
+
+
+@pytest.mark.parametrize("periodic_domain", [True])
+def test_spectral_noise(periodic_domain):
+    """
+    1. White noise -> equal amplitude in all wavenumbers:
+        - variance in radial 1d psd should be amp**2*pi/4
+        - azimuthal spectrum should be approximately uniform over sectors, so
+          anisotropy should -> 0
+        - radial spectrum (integrated over rings) should increase linearly 
+          with k1d, i.e.:
+         - spectral slopes -> 1
+         - median l_spec: triangular spectrum -> 1/3 of variance is encountered at 
+           sqrt(3)/3 of max wavenumber N/2 -> spectral length scale should be 
+           1/(sqrt(3)/3*N/2*1/L), or more simply 2*sqrt(3)*dx
+         - mean l_spec should then occur at wavenumber 2/3*kmax, or l_spec -> 3*dx
+    """
+
+    amp = 1
+    dx = 1000
+    sh = 512
+
+    rng = np.random.default_rng(0)
+    cloud_scalar = rng.normal(0, amp, size=sh * sh).reshape((sh, sh))
+
+    k1d, psd_1d_rad, psd_1d_azi = cloudmetrics.compute_spectra(
+        cloud_scalar,
+        dx=dx,
+        periodic_domain=periodic_domain,
+        apply_detrending=False,
+        window=None,
+    )
+
+    variance_psd = np.sum(psd_1d_rad) * 2 * np.pi / (dx * sh)
+    anisotropy = cloudmetrics.spectral_anisotropy(psd_1d_azi)
+    beta = cloudmetrics.spectral_slope(k1d, psd_1d_rad)
+    beta_binned = cloudmetrics.spectral_slope_binned(k1d, psd_1d_rad)
+    l_spec_median = cloudmetrics.spectral_length_median(k1d, psd_1d_rad)
+    l_spec_moment = cloudmetrics.spectral_length_moment(k1d, psd_1d_rad)
+
+    np.testing.assert_allclose(variance_psd, amp ** 2 * np.pi / 4, 0.01)
+    np.testing.assert_allclose(anisotropy, 0.0, atol=0.1)
+    np.testing.assert_allclose(beta, 1, atol=0.01)
+    np.testing.assert_allclose(beta_binned, 1, atol=0.1)
+    np.testing.assert_allclose(l_spec_median, 2 * np.sqrt(3) * dx, atol=100)
+    np.testing.assert_allclose(l_spec_moment, 3 * dx, atol=10)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -11,11 +11,11 @@ def test_spectral_noise(periodic_domain):
         - variance in radial 1d psd should be amp**2*pi/4
         - azimuthal spectrum should be approximately uniform over sectors, so
           anisotropy should -> 0
-        - radial spectrum (integrated over rings) should increase linearly 
+        - radial spectrum (integrated over rings) should increase linearly
           with k1d, i.e.:
          - spectral slopes -> 1
-         - median l_spec: triangular spectrum -> 1/3 of variance is encountered at 
-           sqrt(3)/3 of max wavenumber N/2 -> spectral length scale should be 
+         - median l_spec: triangular spectrum -> 1/3 of variance is encountered at
+           sqrt(3)/3 of max wavenumber N/2 -> spectral length scale should be
            1/(sqrt(3)/3*N/2*1/L), or more simply 2*sqrt(3)*dx
          - mean l_spec should then occur at wavenumber 2/3*kmax, or l_spec -> 3*dx
     """


### PR DESCRIPTION
@leifdenby this one might require us to agree on format as well. Currently, I'm writing the Fourier metrics as operating on a power spectral density, that has previously been computed, following the terminology:
```
spectra = cloudmetrics.compute_spectra(cloud_scalar,...)
metric_x = cloudmetrics.spectral_metric(spectra)
```
This allows us to only compute the spectra once before computing the metrics that derive from those spectra. It's a bit explicit and also deviates from the `metric(cloud_scalar)` terminology, but I think this might be clearer. I'm also adding a `compute_all(cloud_scalar)` function that wraps spectrum calculation and all the individual metric calculations.