### PR TITLE
Fix mistakes in README metrics table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The table below gives an overview over which metrics are avaiable in the
 | `mask.network_nn_dist`             | TODO   |                 |                |
 | `mask.cop`                         | TODO   | TODO            |                |
 | `mask.csd`                         | TODO   | TODO            |                |
-| `objects.iorg`                     | ✔️#1    | TODO            |                |
-| `objects.iorg_poisson`             | (✔️)†   | ✔️               |                |
-| `objects.max_length_scale`         | (✔️)†   | ✔️               |                |
-| `objects.mean_eccentricity`        | (✔️)†   | ✔️               |                |
-| `objects.mean_length_scale`        | (✔️)†   | ✔️               |                |
-| `objects.mean_perimeter_length`    | (✔️)†   | ✔️               |                |
+| `objects.iorg`                     | ✔️ #1   | TODO            |                |
+| `objects.iorg_poisson`             | TODO   | TODO            |                |
+| `objects.max_length_scale`         | ✔️†     | ✔️               |                |
+| `objects.mean_eccentricity`        | ✔️†     | ✔️               |                |
+| `objects.mean_length_scale`        | ✔️†     | ✔️               |                |
+| `objects.mean_perimeter_length`    | ✔️†     | ✔️               |                |
 | `objects.rdf`                      | TODO   | TODO            |                |
 | `objects.scai`                     | TODO   | TODO            |                |
 | `scalar.spectral_anisotropy` #2    |        |                 | ✔️              |
@@ -43,9 +43,9 @@ The table below gives an overview over which metrics are avaiable in the
 | `scalar.spectral_length_moment,`#2 |        |                 | ✔️              |
 | `scalar.spectral_slope`#2          |        |                 | ✔️              |
 | `scalar.spectral_slope_binned`#2   |        |                 | ✔️              |
-| `scalar.woi1` #2                   |        |                 | ✔️              |
-| `scalar.woi2` #2                   |        |                 | ✔️              |
-| `scalar.woi3` #2                   |        |                 | ✔️              |
+| `scalar.woi1`                      |        |                 | ✔️              |
+| `scalar.woi2`                      |        |                 | ✔️              |
+| `scalar.woi3`                      |        |                 | ✔️              |
 | `scalar.mean`                      | req'd  |                 | TODO           |
 | `scalar.var`                       | req'd  |                 | TODO           |
 | `scalar.skew`                      | req'd  |                 | TODO           |


### PR DESCRIPTION
- woi metrics already take `scalar_field` as an input
- iog poisson is still TODO
- label for object metrics that work on masks was unclear