### PR TITLE
remove pip install from conda env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,11 @@
   [\#21](https://github.com/cloudsci/cloudmetrics/pull/21). By Leif Denby
   & Martin Janssens (@leifdenby & @martinjanssens)
 
+*maintenance*
+
 - Code cleanup and setup of continuous integration testing
-  [\#19](https://github.com/cloudsci/cloudmetrics/pull/19). By Leif Denby
+  [\#19](https://github.com/cloudsci/cloudmetrics/pull/19),
+  [\#55](https://github.com/cloudsci/cloudmetrics/pull/55). By Leif Denby
   (@leifdenby)
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,3 @@ dependencies:
   - cython
   - pyhdf>=0.10.1
   - pip
-  - pip:
-    - -r file:requirements.txt


### PR DESCRIPTION
ci testing was failing because conda can't find pip requirements.txt file