### PR TITLE
Update black to fix issue with click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: ^(Metrics/)
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
       - id: black-jupyter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
 
 *maintenance*
 
+- update `black` version to address recent breaking change in black's
+  dependency on `click`
+  [\#59](https://github.com/cloudsci/cloudmetrics/pull/59) By Leif Denby
+  (@leifdenby)
+
 - ci action to automatically deploy releases on github to pypi
   [\#53](https://github.com/cloudsci/cloudmetrics/pull/53). By Leif Denby
   (@leifdenby)

--- a/Metrics/cop.py
+++ b/Metrics/cop.py
@@ -115,7 +115,7 @@ class COP:
                 pos_1d = pos[:, d][:, np.newaxis]  # shape (N, 1)
                 dist_1d = sd.pdist(pos_1d)  # shape (N * (N - 1) // 2, )
                 dist_1d[dist_1d > box * 0.5] -= box
-                dist_sq += dist_1d ** 2  # d^2 = dx^2 + dy^2 + dz^2
+                dist_sq += dist_1d**2  # d^2 = dx^2 + dy^2 + dz^2
             dist = np.sqrt(dist_sq)
         else:
             dist = sd.pdist(pos)

--- a/Metrics/fourier.py
+++ b/Metrics/fourier.py
@@ -299,7 +299,7 @@ class FourierMetrics:
         lSpec = 1.0 / kcrit
 
         # Spectral length scale as Jonker et al. (2006), using moments:
-        kMom = np.trapz(psd1 * k1d ** self.expMom, k1d) / varTot
+        kMom = np.trapz(psd1 * k1d**self.expMom, k1d) / varTot
         lSpecMom = 1.0 / kMom
 
         # Plotting

--- a/Metrics/iorg.py
+++ b/Metrics/iorg.py
@@ -36,7 +36,7 @@ def checkOverlap(new, placedCircles):
     for c in placedCircles:
         dx = min(abs(c.x - new.x), abs(c.xm - new.x), abs(c.xp - new.x))
         dy = min(abs(c.y - new.y), abs(c.ym - new.y), abs(c.yp - new.y))
-        if dx ** 2 + dy ** 2 <= (c.r + new.r) ** 2:
+        if dx**2 + dy**2 <= (c.r + new.r) ** 2:
             return True
     return False
 

--- a/Metrics/iorgPoisson.py
+++ b/Metrics/iorgPoisson.py
@@ -127,7 +127,7 @@ class IOrgPoisson:
         # Poisson
         lam = nnScene.shape[0] / (sh[0] * sh[1])
         binav = (bins[1:] + bins[:-1]) / 2
-        nndcdfRand = 1 - np.exp(-lam * np.pi * binav ** 2)
+        nndcdfRand = 1 - np.exp(-lam * np.pi * binav**2)
 
         ## Compute Iorg ##
         iOrg = np.trapz(nndcdfScene, nndcdfRand)

--- a/Metrics/orientation.py
+++ b/Metrics/orientation.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 def raw_moment(data, i_order, j_order):
     nrows, ncols = data.shape
     y_indices, x_indicies = np.mgrid[:nrows, :ncols]
-    return (data * x_indicies ** i_order * y_indices ** j_order).sum()
+    return (data * x_indicies**i_order * y_indices**j_order).sum()
 
 
 def moments_cov(data):

--- a/Metrics/rdf.py
+++ b/Metrics/rdf.py
@@ -81,7 +81,7 @@ def pair_correlation_2d(pos, S, r_max, dr, bc, normalize=True):
             pos_1d = pos[:, d][:, np.newaxis]  # shape (N, 1)
             dist_1d = pdist(pos_1d)  # shape (N * (N - 1) // 2, )
             dist_1d[dist_1d > box * 0.5] -= box
-            dist_sq += dist_1d ** 2
+            dist_sq += dist_1d**2
         dist = np.sqrt(dist_sq)
     else:
         dist = pdist(pos)
@@ -102,7 +102,7 @@ def pair_correlation_2d(pos, S, r_max, dr, bc, normalize=True):
         radii[i] = (edges[i] + edges[i + 1]) / 2.0
         rOuter = edges[i + 1]
         rInner = edges[i]
-        g_average[i] = np.mean(g[:, i]) / (np.pi * (rOuter ** 2 - rInner ** 2))
+        g_average[i] = np.mean(g[:, i]) / (np.pi * (rOuter**2 - rInner**2))
 
     return g_average, radii, int_ind
 

--- a/Metrics/scai.py
+++ b/Metrics/scai.py
@@ -116,7 +116,7 @@ class SCAI:
                 pos_1d = pos[:, d][:, np.newaxis]
                 dist_1d = sd.pdist(pos_1d)
                 dist_1d[dist_1d > box * 0.5] -= box
-                dist_sq += dist_1d ** 2
+                dist_sq += dist_1d**2
             dist = np.sqrt(dist_sq)
         else:
             dist = sd.pdist(pos)

--- a/Metrics/woi.py
+++ b/Metrics/woi.py
@@ -178,7 +178,7 @@ class WOI:
         # Validate wavelet energy spectrum -> if correct total energy should be
         # the same as in image space
         Ewav = np.sum(specs)
-        Eimg = np.mean(cwp ** 2)
+        Eimg = np.mean(cwp**2)
 
         diff = Ewav - Eimg
         if diff < 1e-10:

--- a/cloudmetrics/mask/iorg.py
+++ b/cloudmetrics/mask/iorg.py
@@ -109,7 +109,7 @@ def _check_circle_overlap(new, placedCircles):
     for c in placedCircles:
         dx = min(abs(c.x - new.x), abs(c.xm - new.x), abs(c.xp - new.x))
         dy = min(abs(c.y - new.y), abs(c.ym - new.y), abs(c.yp - new.y))
-        if dx ** 2 + dy ** 2 <= (c.r + new.r) ** 2:
+        if dx**2 + dy**2 <= (c.r + new.r) ** 2:
             return True
     return False
 

--- a/cloudmetrics/mask/orientation.py
+++ b/cloudmetrics/mask/orientation.py
@@ -4,7 +4,7 @@ import numpy as np
 def _raw_moment(data, i_order, j_order):
     nrows, ncols = data.shape
     y_indices, x_indicies = np.mgrid[:nrows, :ncols]
-    return (data * x_indicies ** i_order * y_indices ** j_order).sum()
+    return (data * x_indicies**i_order * y_indices**j_order).sum()
 
 
 def _moments_cov(data):

--- a/cloudmetrics/objects/metrics/cop.py
+++ b/cloudmetrics/objects/metrics/cop.py
@@ -43,7 +43,7 @@ def cop(object_labels, min_area=0, periodic_domain=False):
             pos_1d = pos[:, d][:, np.newaxis]  # shape (N, 1)
             dist_1d = sd.pdist(pos_1d)  # shape (N * (N - 1) // 2, )
             dist_1d[dist_1d > box * 0.5] -= box
-            dist_sq += dist_1d ** 2  # d^2 = dx^2 + dy^2 + dz^2
+            dist_sq += dist_1d**2  # d^2 = dx^2 + dy^2 + dz^2
         dist = np.sqrt(dist_sq)
     else:
         dist = sd.pdist(pos)

--- a/cloudmetrics/objects/metrics/scai.py
+++ b/cloudmetrics/objects/metrics/scai.py
@@ -64,7 +64,7 @@ def scai(
         D0 = scai = np.nan
 
     else:
-        area = area[idx_large_objects] * dx ** 2
+        area = area[idx_large_objects] * dx**2
         pos = centroids[idx_large_objects, :] * dx
         nCl = len(area)
 
@@ -75,7 +75,7 @@ def scai(
                 pos_1d = pos[:, d][:, np.newaxis]
                 dist_1d = sd.pdist(pos_1d)
                 dist_1d[dist_1d > box * 0.5] -= box
-                dist_sq += dist_1d ** 2
+                dist_sq += dist_1d**2
             dist = np.sqrt(dist_sq)
         else:
             dist = sd.pdist(pos)

--- a/cloudmetrics/scalar/spectral.py
+++ b/cloudmetrics/scalar/spectral.py
@@ -46,7 +46,7 @@ def _get_psd_1d_radial(psd_2d, dx):
 
     kp = 2 * np.pi / L * ndimage.sum(r, r_int, index=rp) / Ns
 
-    psd_1d *= L ** 2 * kp / (2 * np.pi * N ** 2 * Ns)
+    psd_1d *= L**2 * kp / (2 * np.pi * N**2 * Ns)
 
     return psd_1d
 
@@ -192,7 +192,7 @@ def _debug_plot(
     axs[0].axis("off")
     axs[0].set_title("Clouds")
     axs[1].scatter(k1d, psd_1d, s=2.5, c="k")
-    axs[1].plot(k1d, b0 * k1d ** beta, c="k")
+    axs[1].plot(k1d, b0 * k1d**beta, c="k")
     axs[1].scatter(bins_centres, psd_bins, s=2.5, c="C1")
     axs[1].axvline(2 * np.pi / l_spec_mom, c="grey")
 
@@ -205,7 +205,7 @@ def _debug_plot(
     axs[1].set_xticks(locas)
     axs[1].set_xticklabels(labes)
 
-    axs[1].plot(bins_centres, b0_binned * bins_centres ** beta_binned, c="C1")
+    axs[1].plot(bins_centres, b0_binned * bins_centres**beta_binned, c="C1")
     axs[1].annotate("Direct", (0.8, 0.9), xycoords="axes fraction", fontsize=10)
     axs[1].annotate(
         r"$R^2$=" + str(round(r_squared_beta, 3)),
@@ -398,7 +398,7 @@ def spectral_slope(k1d, psd_1d_rad, return_intercept=False):
 
     # Unbiased fit of the power law
     _ = np.seterr(over="ignore")
-    [beta, b0], cov = curve_fit(lambda x, a, b: b * x ** a, k1d, psd_1d_rad)
+    [beta, b0], cov = curve_fit(lambda x, a, b: b * x**a, k1d, psd_1d_rad)
 
     if return_intercept:
         return beta, b0
@@ -444,7 +444,7 @@ def spectral_slope_binned(k1d, psd_1d_rad, n_bins=10, return_intercept=False):
         # Unbiased fit of the power law
         _ = np.seterr(over="ignore")
         [beta, b0], cov = curve_fit(
-            lambda x, a, b: b * x ** a, bins_centres[1:-1], psd_bins[1:-1]
+            lambda x, a, b: b * x**a, bins_centres[1:-1], psd_bins[1:-1]
         )
 
     else:
@@ -519,7 +519,7 @@ def spectral_length_moment(k1d, psd_1d_rad, order=1):
     """
 
     kmom = (
-        np.trapz(psd_1d_rad * k1d ** order, k1d) / np.trapz(psd_1d_rad, k1d)
+        np.trapz(psd_1d_rad * k1d**order, k1d) / np.trapz(psd_1d_rad, k1d)
     ) ** 1 / order
     l_spec = 2 * np.pi / kmom
 

--- a/cloudmetrics/scalar/woi.py
+++ b/cloudmetrics/scalar/woi.py
@@ -87,7 +87,7 @@ def compute_swt(cloud_scalar, pad_method, wavelet, separation_scale, debug=False
     for shi in cloud_scalar.shape:
         pow2 = np.log2(shi)
         pow2 = int(pow2 + 1) if pow2 % 1 > 0 else int(pow2)
-        pad = (2 ** pow2 - shi) // 2
+        pad = (2**pow2 - shi) // 2
         pad_sequence.append((pad, pad))
         scale_i.append(pow2)
     cloud_scalar = pywt.pad(cloud_scalar, pad_sequence, pad_method)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -42,7 +42,7 @@ def test_spectral_noise(periodic_domain):
     l_spec_median = cloudmetrics.scalar.spectral_length_median(k1d, psd_1d_rad)
     l_spec_moment = cloudmetrics.scalar.spectral_length_moment(k1d, psd_1d_rad)
 
-    np.testing.assert_allclose(variance_psd, amp ** 2 * np.pi / 4, 0.01)
+    np.testing.assert_allclose(variance_psd, amp**2 * np.pi / 4, 0.01)
     np.testing.assert_allclose(anisotropy, 0.0, atol=0.1)
     np.testing.assert_allclose(beta, 1, atol=0.01)
     np.testing.assert_allclose(beta_binned, 1, atol=0.1)

--- a/tests/test_scai.py
+++ b/tests/test_scai.py
@@ -48,5 +48,5 @@ def test_resolution_doubling():
     # To correct for this we here scale the SCAI values by 1/dx^2 for the
     # examples
     np.testing.assert_almost_equal(
-        scai_value / dx ** 2.0, scai_value_halfdx / dx2 ** 2.0
+        scai_value / dx**2.0, scai_value_halfdx / dx2**2.0
     )


### PR DESCRIPTION
A recent update to the `click` package broke black
(https://github.com/psf/black/issues/2964). The easiest fix is to just
update black. The newest version of black doesn't use spaces around the
power operator (`**`) which looks nicer anyway :)