### PR TITLE
Return only max of open-sky metric by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [unreleased](https://github.com/cloudsci/cloudmetrics/tree/HEAD)
+
+[Full Changelog](https://github.com/cloudsci/cloudmetrics/compare/v0.2.0...HEAD)
+
+*changed defaults*
+
+- open-sky metric calculation (`mask.open_sky`) now only returns max-value by
+  default [\#65](https://github.com/cloudsci/cloudmetrics/pull/65) Leif Denby
+  (@leifdenby)
+
 ## [v0.2.0](https://github.com/cloudsci/cloudmetrics/tree/v0.2.0)
 
 [Full Changelog](https://github.com/cloudsci/cloudmetrics/compare/v0.1.0...v0.2.0)

--- a/cloudmetrics/mask/open_sky.py
+++ b/cloudmetrics/mask/open_sky.py
@@ -12,8 +12,9 @@ def open_sky(mask, summary_measure="max", periodic_domain=False, debug=False):
     The method analyses rectangular reference areas in the scene defined by
     four extrema in east, west, north and south.  These points are the distance
     from each pixel where the mask is 0, to the nearest pixel in each direction
-    where the mask is 1. The largest and average such area are both returned as
-    metrics for the size of the scene's voids (contiguous areas where the mask is 0).
+    where the mask is 1. Both the largest and average of such areas can be
+    return as measures of size of the scene's voids (contiguous areas where the
+    mask is 0).
 
     NOTE: for situations where the large clear-sky swaths are absent from the
     `mask` (for example in LES simulations) returning the `mean` rather than

--- a/cloudmetrics/mask/open_sky.py
+++ b/cloudmetrics/mask/open_sky.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def open_sky(mask, periodic_domain=False, debug=False):
+def open_sky(mask, return_avg=False, periodic_domain=False, debug=False):
     """
     Compute "open sky" metric proposed by Antonissen (2018) for a single
     (cloud) mask (see http://resolver.tudelft.nl/uuid:d868273a-b028-4273-8380-ff1628ecabd5).
@@ -22,6 +22,8 @@ def open_sky(mask, periodic_domain=False, debug=False):
     periodic_domain: whether the provided (cloud) mask is on a periodic domain
                      (for example from a LES simulation)
     debug:           whether to produce debugging plot
+    return_avg:      whether to return average value (as well as the max) of
+                     the open sky metric
 
     Returns
     -------
@@ -93,7 +95,10 @@ def open_sky(mask, periodic_domain=False, debug=False):
     if debug:
         _debug_plot(mask=mask, osc=osc, wmax=wmax, nmax=nmax, emax=emax, smax=smax)
 
-    return os_max, a_os_avg
+    if not return_avg:
+        return os_max
+    else:
+        return os_max, a_os_avg
 
 
 def _debug_plot(mask, osc, wmax, nmax, emax, smax):

--- a/cloudmetrics/mask/open_sky.py
+++ b/cloudmetrics/mask/open_sky.py
@@ -12,9 +12,9 @@ def open_sky(mask, summary_measure="max", periodic_domain=False, debug=False):
     The method analyses rectangular reference areas in the scene defined by
     four extrema in east, west, north and south.  These points are the distance
     from each pixel where the mask is 0, to the nearest pixel in each direction
-    where the mask is 1. Both the largest and average of such areas can be
-    return as measures of size of the scene's voids (contiguous areas where the
-    mask is 0).
+    where the mask is 1. Both the largest (default) and average of such areas
+    can be return as measures of size of the scene's voids (contiguous areas
+    where the mask is 0).
 
     NOTE: for situations where the large clear-sky swaths are absent from the
     `mask` (for example in LES simulations) returning the `mean` rather than

--- a/tests/test_open_sky.py
+++ b/tests/test_open_sky.py
@@ -36,8 +36,12 @@ EXAMPLE_MASK = _parse_example_mask(EXAMPLE_MASKS_STRING)
 
 @pytest.mark.parametrize("periodic_domain", [True, False])
 def test_open_sky(periodic_domain):
-    os_max, os_avg = cloudmetrics.mask.open_sky(
-        mask=EXAMPLE_MASK, periodic_domain=periodic_domain, return_avg=True
+    os_max = cloudmetrics.mask.open_sky(
+        mask=EXAMPLE_MASK,
+        periodic_domain=periodic_domain,
+    )
+    os_avg = cloudmetrics.mask.open_sky(
+        mask=EXAMPLE_MASK, periodic_domain=periodic_domain, summary_measure="mean"
     )
 
     assert not np.isnan(os_max)

--- a/tests/test_open_sky.py
+++ b/tests/test_open_sky.py
@@ -37,7 +37,7 @@ EXAMPLE_MASK = _parse_example_mask(EXAMPLE_MASKS_STRING)
 @pytest.mark.parametrize("periodic_domain", [True, False])
 def test_open_sky(periodic_domain):
     os_max, os_avg = cloudmetrics.mask.open_sky(
-        mask=EXAMPLE_MASK, periodic_domain=periodic_domain
+        mask=EXAMPLE_MASK, periodic_domain=periodic_domain, return_avg=True
     )
 
     assert not np.isnan(os_max)


### PR DESCRIPTION
Previously both the max and average value of the open-sky metric was returned, however a sensible default for any metric should return only a single scalar value. Based on Antonissen 2018
(http://resolver.tudelft.nl/uuid:d868273a-b028-4273-8380-ff1628ecabd5) the maximum value of the open-sky metric is the default characteristic used.