### PR TITLE
Updated isort from 5.10.1 to 5.11.5 and removed nb-black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-yaml
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
         exclude: ^(Metrics/)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ where=.
 test =
   pytest
   nbval
-  nb-black
+#  nb-black
 dev =
   %(test)s
   pre-commit


### PR DESCRIPTION
To allow pre-commit to continue functioning. Could have gone for an update to 5.12.0, but that would remove support for Python 3.7. Going that far might better be part of a bigger update?

This PR also comments nb-black from the testing, since it does not currently work (see https://github.com/dnanhkhoa/nb_black/issues/40).