### PR TITLE
Removed caching from _get_regionprops, and instead compute these always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 
 *maintenance*
 
+- removed caching of regionproperties for each image that is calculated, to
+  prevent memory accumulation
+  [\#73](https://github.com/cloudsci/cloudmetrics/pull/73) Martin Janssens
+- updated isort and removed nb-black to work with latest package versions
+  [\#71](https://github.com/cloudsci/cloudmetrics/pull/71) Martin Janssens
+- handle fully cloudy scenes in open-sky metric (previously broke, now returns
+  zero)
+  [\#67] (https://github.com/cloudsci/cloudmetrics/pull/67) Leif Denby
 - add zenodo DOI badge and citation information
   [\#66](https://github.com/cloudsci/cloudmetrics/pull/66) Leif Denby
   (@leifdenby)

--- a/cloudmetrics/objects/metrics/_object_properties.py
+++ b/cloudmetrics/objects/metrics/_object_properties.py
@@ -1,26 +1,8 @@
 import numpy as np
 from skimage.measure import regionprops
 
-# Legacy _get_regionprops, which used a cache that was i) not that big of a performance boost (regionprops is fast), ii) did not actually work when objects were computed from masks directly and iii) kept accumulating memory
-# from hashlib import sha1
-# _CACHED_VALUES = dict()
-#
-# def _get_regionprops(object_labels):
-#     # need a unique ID for each object-label array (for a poor-mans
-#     # caching to avoid recalculation of the object properties).
-#     # Can't use python's memory ID of the labels array because these can
-#     # sometimes get shared if numpy reuses the array memory, instead we compute
-#     # a hash
-#     array_id = sha1(object_labels)
-#     if array_id in _CACHED_VALUES:
-#         return _CACHED_VALUES[array_id]
-#
-#     regions = regionprops(label_image=object_labels)
-#     _CACHED_VALUES[array_id] = regions
-#     return regions
 
-
-# Now we just compute them every time
+# Compute regionprops for every image, for every metric, that is passed.
 def _get_regionprops(object_labels):
     return regionprops(label_image=object_labels)
 

--- a/cloudmetrics/objects/metrics/_object_properties.py
+++ b/cloudmetrics/objects/metrics/_object_properties.py
@@ -1,24 +1,28 @@
-from hashlib import sha1
-
 import numpy as np
 from skimage.measure import regionprops
 
-_CACHED_VALUES = dict()
+# Legacy _get_regionprops, which used a cache that was i) not that big of a performance boost (regionprops is fast), ii) did not actually work when objects were computed from masks directly and iii) kept accumulating memory
+# from hashlib import sha1
+# _CACHED_VALUES = dict()
+#
+# def _get_regionprops(object_labels):
+#     # need a unique ID for each object-label array (for a poor-mans
+#     # caching to avoid recalculation of the object properties).
+#     # Can't use python's memory ID of the labels array because these can
+#     # sometimes get shared if numpy reuses the array memory, instead we compute
+#     # a hash
+#     array_id = sha1(object_labels)
+#     if array_id in _CACHED_VALUES:
+#         return _CACHED_VALUES[array_id]
+#
+#     regions = regionprops(label_image=object_labels)
+#     _CACHED_VALUES[array_id] = regions
+#     return regions
 
 
+# Now we just compute them every time
 def _get_regionprops(object_labels):
-    # need a unique ID for each object-label array (for a poor-mans
-    # caching to avoid recalculation of the object properties).
-    # Can't use python's memory ID of the labels array because these can
-    # sometimes get shared if numpy reuses the array memory, instead we compute
-    # a hash
-    array_id = sha1(object_labels)
-    if array_id in _CACHED_VALUES:
-        return _CACHED_VALUES[array_id]
-
-    regions = regionprops(label_image=object_labels)
-    _CACHED_VALUES[array_id] = regions
-    return regions
+    return regionprops(label_image=object_labels)
 
 
 def _get_objects_property(object_labels, property_name):


### PR DESCRIPTION
To deal with #70, I've removed the caching from `_get_regionprops`, since

1. It wasn't that big of a performance boost anyway
2. It didn't actually do anything if the object metrics were computed from masks directly, since e.g. `cloudmetrics.mask.iorg_objects(da_cloudmask)` first does a `label_objects(da_mask)` anyway, which gives a unique array of `object_labels` per function call, so `_get_regionprops` would just make a new cache entry for these instead of reusing the cache
3. The cache now no longer accumulates memory
4. We don't build assumptions into the library on the order that people want to compute metrics in (releasing the cache whenever a new scene comes by sort of imposes a workflow where people first loop over scenes, so that scene can be reused)

I've kept the legacy code, in case we want to reintroduce a cache at some point.